### PR TITLE
feat(formatter)!: removed error return from Format method

### DIFF
--- a/nepalitime/formatter.go
+++ b/nepalitime/formatter.go
@@ -1,7 +1,6 @@
 package nepalitime
 
 import (
-	"errors"
 	"strconv"
 	"strings"
 )
@@ -14,7 +13,7 @@ type NepaliFormatter struct {
 	nepaliTime *NepaliTime
 }
 
-func (obj *NepaliFormatter) Format(format string) (string, error) {
+func (obj *NepaliFormatter) Format(format string) string {
 	index, num, timeStr := 0, len(format), ""
 
 	for index < num {
@@ -32,17 +31,11 @@ func (obj *NepaliFormatter) Format(format string) (string, error) {
 				if (index + 1) < num {
 					index++
 					char = string(format[index])
-					res, err := obj.getFormatString(specialChar + char)
-					if err != nil {
-						return "", errors.New("error while formatting NepaliTime with given format")
-					}
+					res := obj.getFormatString(specialChar + char)
 					timeStr += res
 				}
 			} else {
-				res, err := obj.getFormatString(char)
-				if err != nil {
-					return "", errors.New("error while formatting NepaliTime with given format")
-				}
+				res := obj.getFormatString(char)
 				timeStr += res
 			}
 			index++
@@ -51,48 +44,49 @@ func (obj *NepaliFormatter) Format(format string) (string, error) {
 		}
 	}
 
-	return timeStr, nil
+	return timeStr
 }
 
 // utility method that operates based on the type of directive
-func (obj *NepaliFormatter) getFormatString(directive string) (string, error) {
+func (obj *NepaliFormatter) getFormatString(directive string) string {
 	switch directive {
 	case "d":
-		return obj.day_(), nil
+		return obj.day_()
 	case "-d":
-		return obj.dayNonzero(), nil
+		return obj.dayNonzero()
 	case "m":
-		return obj.monthNumber(), nil
+		return obj.monthNumber()
 	case "-m":
-		return obj.monthNumberNonzero(), nil
+		return obj.monthNumberNonzero()
 	case "y":
-		return obj.yearHalf(), nil
+		return obj.yearHalf()
 	case "Y":
-		return obj.yearFull(), nil
+		return obj.yearFull()
 	case "H":
-		return obj.hour24(), nil
+		return obj.hour24()
 	case "-H":
-		return obj.hour24Nonzero(), nil
+		return obj.hour24Nonzero()
 	case "I":
-		return obj.hour12(), nil
+		return obj.hour12()
 	case "-I":
-		return obj.hour12Nonzero(), nil
+		return obj.hour12Nonzero()
 	case "p":
-		return obj.ampm(), nil
+		return obj.ampm()
 	case "M":
-		return obj.minute(), nil
+		return obj.minute()
 	case "-M":
-		return obj.minuteNonzero(), nil
+		return obj.minuteNonzero()
 	case "S":
-		return obj.second(), nil
+		return obj.second()
 	case "-S":
-		return obj.secondNonzero(), nil
+		return obj.secondNonzero()
 	case "f":
-		return obj.nanosecond_(), nil
+		return obj.nanosecond_()
 	case "-f":
-		return obj.nanosecondNonZero(), nil
+		return obj.nanosecondNonZero()
 	default:
-		return "", errors.New("error while getting format string for passed directive")
+		// if not match return the directive
+		return "%" + directive
 	}
 }
 

--- a/nepalitime/formatter_test.go
+++ b/nepalitime/formatter_test.go
@@ -9,254 +9,252 @@ import (
 
 func TestNepaliFormatterFormatYmdSlash(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTime)
-	res, _ := formatter.Format("%Y/%m/%d")
+	res := formatter.Format("%Y/%m/%d")
 
 	assert.Equal(t, "2079/10/14", res, "%Y/%m/%d did not match")
 }
 
 func TestNepaliFormatterFormatymdSlash(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTime)
-	res, _ := formatter.Format("%y/%m/%d")
+	res := formatter.Format("%y/%m/%d")
 
 	assert.Equal(t, "79/10/14", res, "%y/%m/%d did not match")
 }
 
 func TestNepaliFormatterFormatdmYSlash(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTime)
-	res, _ := formatter.Format("%d/%m/%Y")
+	res := formatter.Format("%d/%m/%Y")
 
 	assert.Equal(t, "14/10/2079", res, "%d/%m/%Y did not match")
 }
 
 func TestNepaliFormatterFormatdmySlash(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTime)
-	res, _ := formatter.Format("%d/%m/%y")
+	res := formatter.Format("%d/%m/%y")
 
 	assert.Equal(t, "14/10/79", res, "%d/%m/%y did not match")
 }
 
 func TestNepaliFormatterFormatmdYSlash(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTime)
-	res, _ := formatter.Format("%m/%d/%Y")
+	res := formatter.Format("%m/%d/%Y")
 
 	assert.Equal(t, "10/14/2079", res, "%d/%m/%Y did not match")
 }
 
 func TestNepaliFormatterFormatmdySlash(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTime)
-	res, _ := formatter.Format("%m/%d/%y")
+	res := formatter.Format("%m/%d/%y")
 
 	assert.Equal(t, "10/14/79", res, "%d/%m/%y did not match")
 }
 
 func TestNepaliFormatterFormatYmdDash(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTime)
-	res, _ := formatter.Format("%Y-%m-%d")
+	res := formatter.Format("%Y-%m-%d")
 
 	assert.Equal(t, "2079-10-14", res, "%Y-%m-%d did not match")
 }
 
 func TestNepaliFormatterFormatymdDash(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTime)
-	res, _ := formatter.Format("%y-%m-%d")
+	res := formatter.Format("%y-%m-%d")
 
 	assert.Equal(t, "79-10-14", res, "%y-%m-%d did not match")
 }
 
 func TestNepaliFormatterFormatdmYDash(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTime)
-	res, _ := formatter.Format("%d-%m-%Y")
+	res := formatter.Format("%d-%m-%Y")
 
 	assert.Equal(t, "14-10-2079", res, "%d-%m-%Y did not match")
 }
 
 func TestNepaliFormatterFormatdmyDash(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTime)
-	res, _ := formatter.Format("%d-%m-%y")
+	res := formatter.Format("%d-%m-%y")
 
 	assert.Equal(t, "14-10-79", res, "%d-%m-%y did not match")
 }
 
 func TestNepaliFormatterFormatmdYDash(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTime)
-	res, _ := formatter.Format("%m-%d-%Y")
+	res := formatter.Format("%m-%d-%Y")
 
 	assert.Equal(t, "10-14-2079", res, "%m-%d-%Y did not match")
 }
 
 func TestNepaliFormatterFormatmdyDash(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTime)
-	res, _ := formatter.Format("%m-%d-%y")
+	res := formatter.Format("%m-%d-%y")
 
 	assert.Equal(t, "10-14-79", res, "%m-%d-%y did not match")
 }
 
 func TestNepaliFormatterFormatYmdHMSSlash(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTime)
-	res, _ := formatter.Format("%Y/%m/%d %H:%M:%S")
+	res := formatter.Format("%Y/%m/%d %H:%M:%S")
 
 	assert.Equal(t, "2079/10/14 16:23:17", res, "%Y/%m/%d %H:%M:%S did not match")
 }
 
 func TestNepaliFormatterFormatYmdIMSPSlash(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTime)
-	res, _ := formatter.Format("%Y/%m/%d %I:%M:%S %p")
+	res := formatter.Format("%Y/%m/%d %I:%M:%S %p")
 
 	assert.Equal(t, "2079/10/14 04:23:17 PM", res, "%Y/%m/%d %I:%M:%S %p did not match")
 }
 
 func TestNepaliFormatterFormatYmdIMSWithoutAMPMSlash(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTime)
-	res, _ := formatter.Format("%Y/%m/%d %I:%M:%S")
+	res := formatter.Format("%Y/%m/%d %I:%M:%S")
 
 	assert.Equal(t, "2079/10/14 04:23:17", res, "%Y/%m/%d %I:%M:%S did not match")
 }
 
 func TestNepaliFormatterFormatYmdIMSfSlash(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTimeLeadingZeros)
-	res, _ := formatter.Format("%Y/%m/%d %I:%M:%S:%f")
+	res := formatter.Format("%Y/%m/%d %I:%M:%S:%f")
 
 	assert.Equal(t, "2079/01/02 03:04:05:000111", res, "%Y/%m/%d %I:%M:%S:%f did not match")
 }
 
 func TestNepaliFormatterFormatYmdSlashNoLeadingZero(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTimeLeadingZeros)
-	res, _ := formatter.Format("%Y/%-m/%-d")
+	res := formatter.Format("%Y/%-m/%-d")
 
 	assert.Equal(t, "2079/1/2", res, "%Y/%-m/%-d did not match")
 }
 
 func TestNepaliFormatterFormatymdSlashNoLeadingZero(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTimeLeadingZeros)
-	res, _ := formatter.Format("%y/%-m/%-d")
+	res := formatter.Format("%y/%-m/%-d")
 
 	assert.Equal(t, "79/1/2", res, "%y/%-m/%-d did not match")
 }
 
 func TestNepaliFormatterFormatdmYSlashNoLeadingZero(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTimeLeadingZeros)
-	res, _ := formatter.Format("%-d/%-m/%Y")
+	res := formatter.Format("%-d/%-m/%Y")
 
 	assert.Equal(t, "2/1/2079", res, "%-d/%-m/%Y did not match")
 }
 
 func TestNepaliFormatterFormatdmySlashNoLeadingZero(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTimeLeadingZeros)
-	res, _ := formatter.Format("%-d/%-m/%y")
+	res := formatter.Format("%-d/%-m/%y")
 
 	assert.Equal(t, "2/1/79", res, "%-d/%-m/%y did not match")
 }
 
 func TestNepaliFormatterFormatmdYSlashNoLeadingZero(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTimeLeadingZeros)
-	res, _ := formatter.Format("%-m/%-d/%Y")
+	res := formatter.Format("%-m/%-d/%Y")
 
 	assert.Equal(t, "1/2/2079", res, "%-d/%-m/%Y did not match")
 }
 
 func TestNepaliFormatterFormatmdySlashNoLeadingZero(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTimeLeadingZeros)
-	res, _ := formatter.Format("%-m/%-d/%y")
+	res := formatter.Format("%-m/%-d/%y")
 
 	assert.Equal(t, "1/2/79", res, "%-d/%-m/%y did not match")
 }
 
 func TestNepaliFormatterFormatYmdIMSfSlashNoLeadingZero(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTimeLeadingZeros)
-	res, _ := formatter.Format("%Y/%-m/%-d %-I:%-M:%-S:%-f")
+	res := formatter.Format("%Y/%-m/%-d %-I:%-M:%-S:%-f")
 
 	assert.Equal(t, "2079/1/2 3:4:5:111", res, "%Y/%-m/%-d %-I:%-M:%-S:%-f did not match")
 }
 
 func TestNepaliFormatterFormatYmdDashNoLeadingZero(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTimeLeadingZeros)
-	res, _ := formatter.Format("%Y-%-m-%-d")
+	res := formatter.Format("%Y-%-m-%-d")
 
 	assert.Equal(t, "2079-1-2", res, "%Y-%-m-%-d did not match")
 }
 
 func TestNepaliFormatterFormatymdDashNoLeadingZero(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTimeLeadingZeros)
-	res, _ := formatter.Format("%y-%-m-%-d")
+	res := formatter.Format("%y-%-m-%-d")
 
 	assert.Equal(t, "79-1-2", res, "%y-%-m-%-d did not match")
 }
 
 func TestNepaliFormatterFormatdmYDashNoLeadingZero(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTimeLeadingZeros)
-	res, _ := formatter.Format("%-d-%-m-%Y")
+	res := formatter.Format("%-d-%-m-%Y")
 
 	assert.Equal(t, "2-1-2079", res, "%-d-%-m-%Y did not match")
 }
 
 func TestNepaliFormatterFormatdmyDashLeadingZero(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTimeLeadingZeros)
-	res, _ := formatter.Format("%-d-%-m-%y")
+	res := formatter.Format("%-d-%-m-%y")
 
 	assert.Equal(t, "2-1-79", res, "%-d-%-m-%y did not match")
 }
 
 func TestNepaliFormatterFormatmdYDashNoLeadingZero(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTimeLeadingZeros)
-	res, _ := formatter.Format("%-m-%-d-%Y")
+	res := formatter.Format("%-m-%-d-%Y")
 
 	assert.Equal(t, "1-2-2079", res, "%-d-%-m-%Y did not match")
 }
 
 func TestNepaliFormatterFormatmdyDashNoLeadingZero(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTimeLeadingZeros)
-	res, _ := formatter.Format("%-m-%-d-%y")
+	res := formatter.Format("%-m-%-d-%y")
 
 	assert.Equal(t, "1-2-79", res, "%-d-%-m-%y did not match")
 }
 
 func TestNepaliFormatterFormatYmdHMSSlashNoLeadingZero(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTimeLeadingZeros)
-	res, _ := formatter.Format("%Y/%-m/%-d %-H:%-M:%-S")
+	res := formatter.Format("%Y/%-m/%-d %-H:%-M:%-S")
 
 	assert.Equal(t, "2079/1/2 3:4:5", res, "%Y/%-m/%-d %-H:%-M:%-S did not match")
 }
 
 func TestNepaliFormatterFormatYmdIMSfDashNoLeadingZero(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTimeLeadingZeros)
-	res, _ := formatter.Format("%Y-%-m-%-d %-I-%-M-%-S-%-f")
+	res := formatter.Format("%Y-%-m-%-d %-I-%-M-%-S-%-f")
 
 	assert.Equal(t, "2079-1-2 3-4-5-111", res, "%Y-%-m-%-d %-I-%-M-%-S-%-f did not match")
 }
 
 func TestNepaliFormatterFormatSpecialCharacters(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTime)
-	res, _ := formatter.Format("%Y/%m/%d %I:%M:%S $*#()%%")
+	res := formatter.Format("%Y/%m/%d %I:%M:%S $*#()%%")
 
 	assert.Equal(t, "2079/10/14 04:23:17 $*#()%", res, "%Y/%m/%d %I:%M:%S $*#()%% did not match")
 }
 
 func TestNepaliFormatterFormatSpecialCharactersBetweenYearAndMonth(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTime)
-	res, _ := formatter.Format("%Y/$*#()%%%m/%d")
+	res := formatter.Format("%Y/$*#()%%%m/%d")
 
 	assert.Equal(t, "2079/$*#()%10/14", res, "%Y/%m/%d %I:%M:%S:%f did not match")
 }
 
-func TestNepaliFormatterFormatErrornouseFormats(t *testing.T) {
+func TestNepaliFormatterFormatReturnAsItIsOnUnknownFormats(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTime)
-	res, err := formatter.Format("%k")
+	res := formatter.Format("%k")
 
-	assert.Equal(t, res, "", "response should be empty string")
-	assert.EqualError(t, err, "error while formatting NepaliTime with given format", "error message not matched")
+	assert.Equal(t, res, "%k", "Unknown format didn't returned as it is")
 }
 
-func TestNepaliFormatterFormatErrornouseFormatsNoLeadingZeros(t *testing.T) {
+func TestNepaliFormatterFormatReturnAsItIsOnUnknownFormatsNoLeadingZeros(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTime)
-	res, err := formatter.Format("%-k")
+	res := formatter.Format("%-k")
 
-	assert.Equal(t, res, "", "response should be empty string")
-	assert.EqualError(t, err, "error while formatting NepaliTime with given format", "error message not matched")
+	assert.Equal(t, res, "%-k", "Unknown format didn't returned as it is")
 }
 
 func TestNepaliFormatterFormatWithoutYear(t *testing.T) {
 	formatter := nepalitime.NewFormatter(globalNepaliTime)
-	res, _ := formatter.Format("%m/%d")
+	res := formatter.Format("%m/%d")
 
 	assert.Equal(t, res, "10/14", "%m/%d did not match")
 }
@@ -264,7 +262,7 @@ func TestNepaliFormatterFormatWithoutYear(t *testing.T) {
 func TestNepaliFormatterFormatHourLessThan10(t *testing.T) {
 	date, _ := nepalitime.Date(2079, 11, 4, 9, 10, 11, 123)
 	formatter := nepalitime.NewFormatter(date)
-	res, _ := formatter.Format("%Y/%m/%d %H::%M::%S::%f")
+	res := formatter.Format("%Y/%m/%d %H::%M::%S::%f")
 
 	assert.Equal(t, "2079/11/04 09::10::11::000123", res, "%Y/%m/%d %H::%M::%S::%f did not match")
 }
@@ -272,7 +270,7 @@ func TestNepaliFormatterFormatHourLessThan10(t *testing.T) {
 func TestNepaliFormatterFormatHourEqualTo0(t *testing.T) {
 	date, _ := nepalitime.Date(2079, 11, 4, 0, 10, 11, 123)
 	formatter := nepalitime.NewFormatter(date)
-	res, _ := formatter.Format("%Y/%m/%d %I::%M::%S::%f")
+	res := formatter.Format("%Y/%m/%d %I::%M::%S::%f")
 
 	assert.Equal(t, "2079/11/04 12::10::11::000123", res, "%Y/%m/%d %I::%M::%S::%f did not match")
 }
@@ -280,7 +278,7 @@ func TestNepaliFormatterFormatHourEqualTo0(t *testing.T) {
 func TestNepaliFormatterFormatHourGreaterThan12(t *testing.T) {
 	date, _ := nepalitime.Date(2079, 11, 4, 13, 10, 11, 123)
 	formatter := nepalitime.NewFormatter(date)
-	res, _ := formatter.Format("%Y/%m/%d %-I::%M::%S::%f")
+	res := formatter.Format("%Y/%m/%d %-I::%M::%S::%f")
 
 	assert.Equal(t, "2079/11/04 1::10::11::000123", res, "%Y/%m/%d %-I::%M::%S::%f did not match")
 }

--- a/nepalitime/nepalitime.go
+++ b/nepalitime/nepalitime.go
@@ -91,13 +91,8 @@ func (obj *NepaliTime) Nanosecond() int {
 }
 
 // formats the nepalitime object into the passed format
-func (obj *NepaliTime) Format(format string) (string, error) {
+func (obj *NepaliTime) Format(format string) string {
 	formatter := NewFormatter(obj)
 
-	formattedNepaliTime, err := formatter.Format(format)
-	if err != nil {
-		return "", err
-	}
-
-	return formattedNepaliTime, nil
+	return formatter.Format(format)
 }

--- a/nepalitime/nepalitime_test.go
+++ b/nepalitime/nepalitime_test.go
@@ -88,14 +88,13 @@ func TestNepaliTimeNanosecond(t *testing.T) {
 }
 
 func TestNepaliTimeFormat(t *testing.T) {
-	res, _ := globalNepaliTime.Format("%Y/%m/%d")
+	res := globalNepaliTime.Format("%Y/%m/%d")
 
 	assert.Equal(t, "2079/10/14", res, "%Y/%m/%d formatting did not match")
 }
 
-func TestNepaliTimeFormatReturnErrorOnInvalidFormat(t *testing.T) {
-	res, err := globalNepaliTime.Format("%k")
+func TestNepaliTimeFormatReturnAsItIsOnUnknownFormat(t *testing.T) {
+	res := globalNepaliTime.Format("%k")
 
-	assert.Equal(t, "", res, "response should be empty string")
-	assert.EqualError(t, err, "error while formatting NepaliTime with given format", "error message on formatting error did not match")
+	assert.Equal(t, "%k", res, "Unknown format didn't returned as it is")
 }


### PR DESCRIPTION
## Description
[Breaking Change] Removed the error return from the `Format` method of `nepalitime`.

The error was unnecessary and did not match the return values of Go time's Format method. Instead of returning an error for unknown directive formats, it now returns the directive as it is. For instance, "%Y-%m-%k-%d" will return "2018-02-%k-19", where %k is an unknown directive.