### PR TITLE
fix(parser): fixed error messages for parsing

### DIFF
--- a/nepalitime/nepalitimeregex.go
+++ b/nepalitime/nepalitimeregex.go
@@ -2,7 +2,6 @@
 package nepalitime
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -80,7 +79,7 @@ func (obj *nepaliTimeRegex) pattern(format string) (string, error) {
 			processedFormat = fmt.Sprintf("%s%s%s", processedFormat, string(format[:directiveIndex-1]), val)
 			format = string(format[directiveIndex+indexIncrement:])
 		} else {
-			return "", errors.New("no pattern matched")
+			return "", fmt.Errorf("the format '%%%s' isn't supported", directiveToCheck)
 		}
 	}
 

--- a/nepalitime/parser.go
+++ b/nepalitime/parser.go
@@ -13,7 +13,7 @@ func Parse(datetimeStr string, format string) (*NepaliTime, error) {
 	nepalitime, err := validate(datetimeStr, format)
 
 	if err != nil {
-		return nil, errors.New("datetime string did not match with given format")
+		return nil, err
 	}
 
 	return nepalitime, nil
@@ -87,7 +87,7 @@ func extract(datetimeStr string, format string) (map[string]string, error) {
 	match := reCompiledFormat.FindStringSubmatch(datetimeStr)
 
 	if len(match) < 1 {
-		return nil, errors.New("no pattern matched")
+		return nil, errors.New("datetime string did not match with given format")
 	}
 
 	result := make(map[string]string)
@@ -211,7 +211,7 @@ func transform(data map[string]string) (map[string]int, error) {
 			fraction, err = strconv.Atoi(s)
 
 			if err != nil {
-				return nil, errors.New("error while getting nanoseconds data")
+				return nil, errors.New("invalid value in %f")
 			}
 		}
 	}

--- a/nepalitime/parser_test.go
+++ b/nepalitime/parser_test.go
@@ -263,7 +263,7 @@ func TestParseWithRandomFormats(t *testing.T) {
 	got, err := nepalitime.Parse(datetimeStr, format)
 
 	assert.Nil(t, got, "NepaliTime object should be nil")
-	assert.EqualError(t, err, "datetime string did not match with given format", "error message did not match")
+	assert.EqualError(t, err, "the format '%k' isn't supported", "error message did not match")
 }
 
 func TestParseForInvalidYear(t *testing.T) {
@@ -273,7 +273,7 @@ func TestParseForInvalidYear(t *testing.T) {
 	got, err := nepalitime.Parse(datetimeStr, format)
 
 	assert.Nil(t, got, "NepaliTime object should be nil")
-	assert.EqualError(t, err, "datetime string did not match with given format", "error message did not match")
+	assert.EqualError(t, err, "date is out of range", "error message did not match")
 }
 
 func TestParseForValidYear(t *testing.T) {


### PR DESCRIPTION
While parsing the datetime string, it shows the wrong message in some cases. This PR fixes the error message.

**Case 1**: Out of Range Date
```bash
npTime, err := nepalitime.Parse("1800-01-01", "%Y-%m-%d")
# Output: datetime string did not match with given format
# Expected: date is out of range
```

**Case 2**: Datetime string without year
```bash
npTime, err := nepalitime.Parse("01-01 %k", "%m-%d %%k");
# Output: datetime string did not match with given format
# Expected: unable to parse year
```
