### PR TITLE
ci: update fail_ci_if_error to false for codecov action

### DIFF
--- a/.github/workflows/nepali-ci.yml
+++ b/.github/workflows/nepali-ci.yml
@@ -34,5 +34,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true


### PR DESCRIPTION
Set fail_ci_if_error to false, since codecov is failing from time to time